### PR TITLE
Add support for remapping coco category ids

### DIFF
--- a/configs/v3-32/mscoco-retinanet-efficientnet-b2-768x768-30x-256.json
+++ b/configs/v3-32/mscoco-retinanet-efficientnet-b2-768x768-30x-256.json
@@ -78,8 +78,9 @@
     "validation_samples": 4952,
     "validation_freq": -1,
     "annotation_file_path": "./instances_val2017.json",
-    "steps_per_execution": 320,
-    "save_every": 8000,
+    "remap_class_ids": true,
+    "steps_per_execution": 128,
+    "save_every": 2560,
     "recovery": {
       "use_inflection_detector": true,
       "metric_key": "l2-regularization",
@@ -89,8 +90,8 @@
     "optimizer": {
       "name": "sgd",
       "momentum": 0.9,
-      "nesterov": false,
-      "global_clipnorm": 16.0,
+      "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": true,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -145,8 +146,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-32/mscoco-retinanet-efficientnet-b3-896x896-30x-256.json
+++ b/configs/v3-32/mscoco-retinanet-efficientnet-b3-896x896-30x-256.json
@@ -78,8 +78,9 @@
     "validation_samples": 4952,
     "validation_freq": -1,
     "annotation_file_path": "./instances_val2017.json",
-    "steps_per_execution": 320,
-    "save_every": 8000,
+    "remap_class_ids": true,
+    "steps_per_execution": 128,
+    "save_every": 2560,
     "recovery": {
       "use_inflection_detector": true,
       "metric_key": "l2-regularization",
@@ -89,8 +90,8 @@
     "optimizer": {
       "name": "sgd",
       "momentum": 0.9,
-      "nesterov": false,
-      "global_clipnorm": 16.0,
+      "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": true,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -145,8 +146,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-32/mscoco-retinanet-resnet50-640x640-30x-256.json
+++ b/configs/v3-32/mscoco-retinanet-resnet50-640x640-30x-256.json
@@ -79,6 +79,7 @@
     "validation_samples": 4952,
     "validation_freq": -1,
     "annotation_file_path": "./instances_val2017.json",
+    "remap_class_ids": true,
     "steps_per_execution": 128,
     "save_every": 2560,
     "recovery": {
@@ -90,7 +91,7 @@
     "optimizer": {
       "name": "sgd",
       "momentum": 0.9,
-      "nesterov": false,
+      "nesterov": true,
       "global_clipnorm": 10.0,
       "use_moving_average": false,
       "moving_average_decay": 0.9998,
@@ -146,8 +147,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-32/mscoco-retinanet-resnet50-640x640-3x-256.json
+++ b/configs/v3-32/mscoco-retinanet-resnet50-640x640-3x-256.json
@@ -81,6 +81,7 @@
     "validation_samples": 4952,
     "validation_freq": -1,
     "annotation_file_path": "./instances_val2017.json",
+    "remap_class_ids": true,
     "steps_per_execution": 128,
     "save_every": 2560,
     "recovery": {

--- a/configs/v3-32/mscoco-retinanet-resnet50-640x640-3x-256.json
+++ b/configs/v3-32/mscoco-retinanet-resnet50-640x640-3x-256.json
@@ -94,6 +94,7 @@
       "name": "sgd",
       "momentum": 0.9,
       "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": true,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -168,7 +169,7 @@
     "shuffle_buffer_size": 10240
   },
   "inference": {
-    "mode": "PerClassHardNMS",
+    "mode": "CombinedNMS",
     "iou_threshold": 0.5,
     "score_threshold": 0.05,
     "soft_nms_sigma": 0.5,

--- a/configs/v3-32/mscoco-retinanet-resnet50-640x640-3x-256.json
+++ b/configs/v3-32/mscoco-retinanet-resnet50-640x640-3x-256.json
@@ -43,7 +43,7 @@
     "head": {
       "num_convs": 4,
       "filters": 256,
-      "num_classes": 91,
+      "num_classes": 80,
       "num_anchors": 9
     }
   },
@@ -141,8 +141,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-32/mscoco-retinanet-resnet50-640x640-3x-256.json
+++ b/configs/v3-32/mscoco-retinanet-resnet50-640x640-3x-256.json
@@ -81,8 +81,8 @@
     "validation_samples": 4952,
     "validation_freq": -1,
     "annotation_file_path": "./instances_val2017.json",
-    "steps_per_execution": 200,
-    "save_every": 10000,
+    "steps_per_execution": 128,
+    "save_every": 2560,
     "recovery": {
       "use_inflection_detector": true,
       "metric_key": "l2-regularization",

--- a/configs/v3-8/mscoco-retinanet-efficientnet-b2-768x768-30x-64.json
+++ b/configs/v3-8/mscoco-retinanet-efficientnet-b2-768x768-30x-64.json
@@ -78,8 +78,9 @@
     "validation_samples": 4952,
     "validation_freq": 1792,
     "annotation_file_path": "./instances_val2017.json",
+    "remap_class_ids": true,
     "steps_per_execution": 128,
-    "save_every": 6400,
+    "save_every": 2560,
     "recovery": {
       "use_inflection_detector": true,
       "metric_key": "l2-regularization",
@@ -89,8 +90,8 @@
     "optimizer": {
       "name": "sgd",
       "momentum": 0.9,
-      "nesterov": false,
-      "global_clipnorm": 16.0,
+      "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": false,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -145,8 +146,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-8/mscoco-retinanet-mobiledet-cpu-448x448-30x-64.json
+++ b/configs/v3-8/mscoco-retinanet-mobiledet-cpu-448x448-30x-64.json
@@ -78,8 +78,9 @@
     "validation_samples": 4952,
     "validation_freq": 1792,
     "annotation_file_path": "./instances_val2017.json",
+    "remap_class_ids": true,
     "steps_per_execution": 128,
-    "save_every": 6400,
+    "save_every": 2560,
     "recovery": {
       "use_inflection_detector": true,
       "metric_key": "l2-regularization",
@@ -89,8 +90,8 @@
     "optimizer": {
       "name": "sgd",
       "momentum": 0.9,
-      "nesterov": false,
-      "global_clipnorm": 16.0,
+      "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": false,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -145,8 +146,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-8/mscoco-retinanet-mobiledet-edge-tpu-448x448-30x-64.json
+++ b/configs/v3-8/mscoco-retinanet-mobiledet-edge-tpu-448x448-30x-64.json
@@ -78,8 +78,9 @@
     "validation_samples": 4952,
     "validation_freq": 1792,
     "annotation_file_path": "./instances_val2017.json",
+    "remap_class_ids": true,
     "steps_per_execution": 128,
-    "save_every": 6400,
+    "save_every": 2560,
     "recovery": {
       "use_inflection_detector": true,
       "metric_key": "l2-regularization",
@@ -89,8 +90,8 @@
     "optimizer": {
       "name": "sgd",
       "momentum": 0.9,
-      "nesterov": false,
-      "global_clipnorm": 16.0,
+      "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": false,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -145,8 +146,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-8/mscoco-retinanet-mobiledet-gpu-512x512-30x-64.json
+++ b/configs/v3-8/mscoco-retinanet-mobiledet-gpu-512x512-30x-64.json
@@ -78,8 +78,9 @@
     "validation_samples": 4952,
     "validation_freq": 1792,
     "annotation_file_path": "./instances_val2017.json",
+    "remap_class_ids": true,
     "steps_per_execution": 128,
-    "save_every": 6400,
+    "save_every": 2560,
     "recovery": {
       "use_inflection_detector": true,
       "metric_key": "l2-regularization",
@@ -89,8 +90,8 @@
     "optimizer": {
       "name": "sgd",
       "momentum": 0.9,
-      "nesterov": false,
-      "global_clipnorm": 16.0,
+      "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": false,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -145,8 +146,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-8/mscoco-retinanet-resnet50-640x640-1x-64.json
+++ b/configs/v3-8/mscoco-retinanet-resnet50-640x640-1x-64.json
@@ -81,6 +81,7 @@
     "validation_samples": 4952,
     "validation_freq": 1792,
     "annotation_file_path": "./instances_val2017.json",
+    "remap_class_ids": true,
     "steps_per_execution": 128,
     "save_every": -1,
     "recovery": {
@@ -93,6 +94,7 @@
       "name": "sgd",
       "momentum": 0.9,
       "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": true,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -141,8 +143,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/configs/v3-8/mscoco-retinanet-resnet50-640x640-30x-64.json
+++ b/configs/v3-8/mscoco-retinanet-resnet50-640x640-30x-64.json
@@ -79,8 +79,9 @@
     "validation_samples": 4952,
     "validation_freq": 1792,
     "annotation_file_path": "./instances_val2017.json",
+    "remap_class_ids": true,
     "steps_per_execution": 128,
-    "save_every": 6400,
+    "save_every": 2560,
     "recovery": {
       "use_inflection_detector": true,
       "metric_key": "l2-regularization",
@@ -90,8 +91,8 @@
     "optimizer": {
       "name": "sgd",
       "momentum": 0.9,
-      "nesterov": false,
-      "global_clipnorm": 16.0,
+      "nesterov": true,
+      "global_clipnorm": 10.0,
       "use_moving_average": false,
       "moving_average_decay": 0.9998,
       "lr_params": {
@@ -146,8 +147,8 @@
   },
   "dataloader_params": {
     "tfrecords": {
-      "train": "gs://tfrc_datasets/coco_tfrecords/train*",
-      "val": "gs://tfrc_datasets/coco_tfrecords/val*"
+      "train": "gs://tfrc_datasets/coco_remapped_tfrecords/train*",
+      "val": "gs://tfrc_datasets/coco_remapped_tfrecords/val*"
     },
     "augmentations": {
       "use_augmentation": true,

--- a/prepare_coco_dataset.sh
+++ b/prepare_coco_dataset.sh
@@ -1,4 +1,5 @@
-sudo apt install aria2
+sudo apt update
+sudo apt install aria2 -y
 mkdir -p $1
 
 aria2c -j 48 -Z \

--- a/prepare_coco_dataset.sh
+++ b/prepare_coco_dataset.sh
@@ -11,4 +11,4 @@ http://images.cocodataset.org/zips/val2017.zip \
 unzip $1/"*".zip -d $1
 mkdir $1/zips && mv $1/*.zip $1/zips
 
-python3 -m retinanet.dataset_utils.create_coco_tfrecords --download_path=$1
+python3 -m retinanet.dataset_utils.create_coco_tfrecords --download_path=$1 --remap_class_ids

--- a/prepare_coco_dataset.sh
+++ b/prepare_coco_dataset.sh
@@ -1,3 +1,4 @@
+sudo apt install aria2
 mkdir -p $1
 
 aria2c -j 48 -Z \

--- a/retinanet/dataset_utils/coco_parser.py
+++ b/retinanet/dataset_utils/coco_parser.py
@@ -12,6 +12,7 @@ class CocoParser(Parser):
 
     def __init__(self,
                  download_path,
+                 remap_class_ids=False,
                  only_mappings=False,
                  only_val=False,
                  skip_crowd=True,
@@ -19,7 +20,10 @@ class CocoParser(Parser):
                  val_annotations_path='annotations/instances_val2017.json',
                  name='COCO',
                  year='2017'):
-        super(CocoParser, self).__init__(download_path, name=name)
+        super(CocoParser, self).__init__(
+            download_path,
+            name=name,
+            remap_class_ids=remap_class_ids)
 
         self._year = year
 
@@ -41,6 +45,9 @@ class CocoParser(Parser):
         self._skipped_annotations = {'train': 0, 'val': 0}
         self._annotation = {}
         self._build_dataset()
+
+        if remap_class_ids:
+            self._remap()
 
     def _build_dataset(self):
 

--- a/retinanet/dataset_utils/create_coco_tfrecords.py
+++ b/retinanet/dataset_utils/create_coco_tfrecords.py
@@ -7,27 +7,32 @@ from absl import app, flags, logging
 from retinanet.dataset_utils.coco_parser import CocoParser
 from retinanet.dataset_utils.tfrecord_writer import TFrecordWriter
 
-flags.DEFINE_string('download_path',
-                    default=None,
-                    help='Path to the downloaded and unzipped COCO files.')
+flags.DEFINE_string(
+    name='download_path',
+    default=None,
+    help='Path to the downloaded and unzipped COCO files.')
 
-flags.DEFINE_integer('num_shards',
-                     default=256,
-                     help='Number of tfrecord files required.')
+flags.DEFINE_integer(
+    name='num_shards',
+    default=256,
+    help='Number of tfrecord files required.')
 
-flags.DEFINE_string('output_dir',
-                    default='./coco_tfrecords',
-                    help='Path to store the generated tfrecords in.')
+flags.DEFINE_string(
+    name='output_dir',
+    default='./coco_tfrecords',
+    help='Path to store the generated tfrecords in.')
 
-flags.DEFINE_boolean('remap_class_ids',
-                     default=False,
-                     help='Remap class ids to make sure they are continuous. '
-                     'MSCOCO dataset has 80 classes but the class ids range '
-                     'from [1, 90], this flag remaps them to [0, 79]')
+flags.DEFINE_boolean(
+    name='remap_class_ids',
+    default=False,
+    help='Remap class ids to make sure they are continuous. '
+    'MSCOCO dataset has 80 classes but the class ids range '
+    'from [1, 90], this flag remaps them to [0, 79]')
 
-flags.DEFINE_boolean('only_dump_parsed_dataset',
-                     default=False,
-                     help='Skip creating tfrecords, dump parsed dataset only')
+flags.DEFINE_boolean(
+    name='only_dump_parsed_dataset',
+    default=False,
+    help='Skip creating tfrecords, dump parsed dataset only')
 
 
 FLAGS = flags.FLAGS

--- a/retinanet/dataset_utils/create_coco_tfrecords.py
+++ b/retinanet/dataset_utils/create_coco_tfrecords.py
@@ -19,6 +19,12 @@ flags.DEFINE_string('output_dir',
                     default='./coco_tfrecords',
                     help='Path to store the generated tfrecords in.')
 
+flags.DEFINE_boolean('remap_class_ids',
+                     default=False,
+                     help='Remap class ids to make sure they are continuous. '
+                     'MSCOCO dataset has 80 classes but the class ids range '
+                     'from [1, 90], this flag remaps them to [0, 79]')
+
 flags.DEFINE_boolean('only_dump_parsed_dataset',
                      default=False,
                      help='Skip creating tfrecords, dump parsed dataset only')
@@ -57,7 +63,10 @@ def main(_):
     if not os.path.exists(FLAGS.output_dir):
         os.mkdir(FLAGS.output_dir)
 
-    coco_parser = CocoParser(FLAGS.download_path)
+    coco_parser = CocoParser(
+      FLAGS.download_path,
+      remap_class_ids=FLAGS.remap_class_ids)
+
     coco_parser.dump_parsed_dataset()
 
     if FLAGS.only_dump_parsed_dataset:

--- a/retinanet/dataset_utils/parser.py
+++ b/retinanet/dataset_utils/parser.py
@@ -43,7 +43,7 @@ class Parser(ABC):
         self.dump_remapping_info()
 
     def _remap(self):
-        old_ids = list(self._class_id_to_class_name.keys())
+        orig_ids = list(self._class_id_to_class_name.keys())
         logging.info('Remapping class ids')
 
         sorted_classes = sorted(self._classes)
@@ -84,14 +84,15 @@ class Parser(ABC):
             'orig_class_id_to_remapped_class_id': orig_class_id_to_remapped_class_id,
             'remapped_class_id_to_orig_class_id': remapped_class_id_to_orig_class_id
         }
+        remapped_ids = list(self._class_id_to_class_name.keys())
         logging.info(
             'Successfully remapped {} classes with class ids ranging from '
             '[{}-{}] to [{}-{}]'.format(
                 len(self._classes),
-                min(old_ids),
-                max(old_ids),
-                0,
-                len(self._classes) - 1))
+                min(orig_ids),
+                max(orig_ids),
+                min(remapped_ids),
+                max(remapped_ids)))
 
     @abstractmethod
     def _build_dataset(self):

--- a/retinanet/dataset_utils/parser.py
+++ b/retinanet/dataset_utils/parser.py
@@ -2,16 +2,19 @@ import json
 from abc import ABC, abstractmethod
 
 from absl import logging
+from tqdm import tqdm
 
 
 class Parser(ABC):
-    def __init__(self, download_path, name='Parser'):
+    def __init__(self, download_path, name='Parser', remap_class_ids=False):
         self._name = '_'.join(name.lower().split())
         self._download_path = download_path
+        self._remap_class_ids = remap_class_ids
         self._data = {'train': [], 'val': []}
         self._classes = set()
         self._class_name_to_class_id = {}
         self._class_id_to_class_name = {}
+        self._remapping_info = {}
 
     def get_class_id(self, class_name=None):
         return self._class_name_to_class_id[class_name]
@@ -28,13 +31,67 @@ class Parser(ABC):
     def dump_parsed_json(self):
         logging.info('Dumping parsed json for {} dataset'.format(self._name))
 
-        with open(self._name + '_parsed_dataset.json', 'w') as f:
-            parsed_dataset = {'name': self._name, 'dataset': self._data}
-            json.dump(parsed_dataset, f, indent=4)
+    def dump_remapping_info(self):
+        logging.info('Dumping remapping info for {} dataset'.format(self._name))
+
+        with open(self._name + '_remapping_info.json', 'w') as f:
+            json.dump(self._remapping_info, f, indent=4)
 
     def dump_parsed_dataset(self):
         self.dump_label_map()
         self.dump_parsed_json()
+        self.dump_remapping_info()
+
+    def _remap(self):
+        old_ids = list(self._class_id_to_class_name.keys())
+        logging.info('Remapping class ids')
+
+        sorted_classes = sorted(self._classes)
+        sorted_class_name_to_class_id = {
+            class_name: idx for idx, class_name in enumerate(sorted_classes)
+            }
+        sorted_class_id_to_class_name = {
+            idx: class_name for idx, class_name in enumerate(sorted_classes)
+            }
+        orig_class_id_to_remapped_class_id = {
+            old_idx: sorted_class_name_to_class_id[class_name]
+            for old_idx, class_name in self._class_id_to_class_name.items()
+            }
+        remapped_class_id_to_orig_class_id = {
+            v: k for k, v in orig_class_id_to_remapped_class_id.items()
+            }
+
+        for split in self._data.keys():
+            if self._data[split] == []:
+                continue
+
+            logging.info('Remapping {} split'.format(split))
+            for i in tqdm(range(len(self._data[split]))):
+                sample = self._data[split][i]
+                old_class_ids = sample['label']['classes']
+                new_class_ids = [orig_class_id_to_remapped_class_id[idx]
+                                 for idx in old_class_ids]
+                sample['label']['classes'] = new_class_ids
+                self._data[split][i] = sample
+
+        self._class_name_to_class_id = sorted_class_name_to_class_id
+        self._class_id_to_class_name = sorted_class_id_to_class_name
+
+        self._remapping_info = {
+            'sorted_classes': sorted_classes,
+            'class_name_to_class_id': sorted_class_name_to_class_id,
+            'class_id_to_class_name': sorted_class_id_to_class_name,
+            'orig_class_id_to_remapped_class_id': orig_class_id_to_remapped_class_id,
+            'remapped_class_id_to_orig_class_id': remapped_class_id_to_orig_class_id
+        }
+        logging.info(
+            'Successfully remapped {} classes with class ids ranging from '
+            '[{}-{}] to [{}-{}]'.format(
+                len(self._classes),
+                min(old_ids),
+                max(old_ids),
+                0,
+                len(self._classes) - 1))
 
     @abstractmethod
     def _build_dataset(self):

--- a/retinanet/eval/coco_evaluator.py
+++ b/retinanet/eval/coco_evaluator.py
@@ -12,18 +12,46 @@ class COCOEvaluator:
             self,
             input_shape,
             annotation_file_path,
-            prediction_file_path):
+            prediction_file_path,
+            remap_class_ids=False):
 
         self._input_shape = input_shape
         self.annotation_file_path = annotation_file_path
         self.prediction_file_path = prediction_file_path
+        self._remap_class_ids = remap_class_ids
 
         self._coco_eval_obj = COCO(annotation_file_path)
+
+        sorted_classes = sorted([
+            category_info['name']
+            for cat_id, category_info in self._coco_eval_obj.cats.items()])
+
+        self._class_name_to_orig_class_id = {
+            category_info['name']: category_info['id']
+            for cat_id, category_info in self._coco_eval_obj.cats.items()
+            }
+        self._sorted_class_name_to_class_id = {
+            class_name: idx for idx, class_name in enumerate(sorted_classes)
+            }
+        self._sorted_class_id_to_class_name = {
+            idx: class_name for idx, class_name in enumerate(sorted_classes)
+            }
 
         self._processed_detections = []
 
         logging.info('Initialized COCOEvaluator with {}'.format(
             self.annotation_file_path))
+
+        if remap_class_ids:
+            logging.warning('Evaluating with `remap_class_ids=True`')
+        else:
+            logging.warning('Evaluating with `remap_class_ids=False`')
+
+    def _maybe_remap_class_ids(self, class_id):
+        if self._remap_class_ids:
+            class_name = self._sorted_class_id_to_class_name[class_id]
+            return self._class_name_to_orig_class_id[class_name]
+        return class_id
 
     def accumulate_results(self, results, rescale_detections=True):
         image_ids = results['image_id']
@@ -58,7 +86,8 @@ class COCOEvaluator:
             for box, int_id, score in zip(boxes, classes, scores):
                 temp_dict = coco_eval_dict.copy()
                 temp_dict['image_id'] = int(image_ids[i])
-                temp_dict['category_id'] = int(int_id)
+                temp_dict['category_id'] = self._maybe_remap_class_ids(
+                    int(int_id))
                 temp_dict['bbox'] = box.tolist()
                 temp_dict['score'] = float(score)
                 self._processed_detections += [temp_dict]

--- a/retinanet/evaluate_saved_model.py
+++ b/retinanet/evaluate_saved_model.py
@@ -33,6 +33,12 @@ flags.DEFINE_string(
     default='predictions.json',
     help='Path to dump predictions json')
 
+flags.DEFINE_boolean(
+    name='remap_class_ids',
+    default=False,
+    help='Enables remapping of class ids. Use only if the model was trained '
+    'with `remap_class_ids=True` in dataset parser')
+
 
 try:
     import tensorrt as trt
@@ -53,9 +59,11 @@ def evaluate(
         return_predictions_only=False):
 
     coco_parser = CocoParser(coco_data_directory, only_val=True)
-    coco_evaluator = COCOEvaluator(None,
-                                   coco_parser.val_annotations_path,
-                                   prediction_file_path)
+    coco_evaluator = COCOEvaluator(
+        input_shape=None,
+        annotation_file_path=coco_parser.val_annotations_path,
+        prediction_file_path=prediction_file_path,
+        remap_class_ids=FLAGS.remap_class_ids)
 
     fps_meter = AverageMeter(name='fps', momentum=0.975)
     num_samples = len(coco_parser.dataset['val'])

--- a/retinanet/executor.py
+++ b/retinanet/executor.py
@@ -65,7 +65,7 @@ class Executor:
         self._run_evaluation_at_end = params.training.validation_freq < 1
         self._summary_writers = {}
 
-        self._current_trial = 0
+        self._current_trial = 1
         if params.training.recovery.use_inflection_detector:
             self._inflection_detector = InflectionDetector(
                 name=params.training.recovery.metric_key,

--- a/retinanet/executor.py
+++ b/retinanet/executor.py
@@ -457,7 +457,8 @@ class Executor:
         evaluator = COCOEvaluator(
             input_shape=self.params.input.input_shape,
             annotation_file_path=self.params.training.annotation_file_path,
-            prediction_file_path=self.name + '.json')
+            prediction_file_path=self.name + '.json',
+            remap_class_ids=self.params.training.remap_class_ids)
 
         logging.info('Evaluating at step {} for {} steps'
                      .format(current_step.numpy(), total_steps))


### PR DESCRIPTION
Remap class ids to make sure they are continuous. MSCOCO dataset has 80 classes but the class ids range  from [1, 90], this adds support  to remap class ids to fall in the range [0, 79]